### PR TITLE
Multi_car_racing and Domain Randomization Progress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Use the official Python image
+FROM python:3.10-slim
+
+# Set the working directory inside the container
+WORKDIR /usr/src/mylib
+
+
+# Install any dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt && pip install tqdm
+
+# You can also install additional tools you might need
+RUN apt-get update && apt-get install -y --fix-missing\
+    libgeos-dev \
+    gcc \        
+    g++ \        
+    swig \       
+    git \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \ 
+    freeglut3-dev \ 
+    xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+# Clone the multi_car_racing repository and install it
+RUN git clone https://github.com/igilitschenski/multi_car_racing.git \
+    && cd multi_car_racing \
+    && pip install -e .
+
+# Copy the Syllabus directory
+COPY . .
+
+WORKDIR /usr/src/mylib/syllabus/examples/experimental
+ENV PYTHONPATH="${PYTHONPATH}:/usr/src/mylib"
+
+CMD ["/bin/bash"]
+
+# docker build -t syllabus-image . 
+# docker run -it --rm -p 4000:4000 syllabus-image
+# docker run -it --rm -p 4000:4000 -v ${PWD}:/usr/src/mylib syllabus-image
+# xvfb-run -s "-screen 0 1400x900x24" python -u multi_car_racing.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 pettingzoo==1.23.0 # upgraded from 1.9 to solve BaseParallelWrapper import (typo)
-supersuit==3.5.0
+# upgraded from 3.5.0 to 3.7.2 (as pettingZoo < 1.23 is a dependency, 
+# the typo error is also present here)
+supersuit==3.7.2 
 gym==0.24.1
 numpy==1.23.3
 wandb>=0.15.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-#pettingzoo==1.19.0
-#supersuit==3.5.0
-gym==0.23.1
+pettingzoo==1.23.0 # upgraded from 1.9 to solve BaseParallelWrapper import (typo)
+supersuit==3.5.0
+gym==0.24.1
 numpy==1.23.3
 wandb>=0.15.3
 grpcio<=1.48.2
@@ -9,7 +9,8 @@ torch>=2.0.1
 ray==2.2.0
 tabulate==0.9.0
 tensorflow_probability
+gymnasium
 
 # documentation
-pip install sphinx-tabs
+# pip install sphinx-tabs
 

--- a/syllabus/core/__init__.py
+++ b/syllabus/core/__init__.py
@@ -1,14 +1,28 @@
+# flake8: noqa
 # Environment Code
-from .task_interface import TaskWrapper, SubclassTaskWrapper, ReinitTaskWrapper, TaskEnv, PettingZooTaskWrapper, PettingZooTaskEnv
+from .curriculum_base import Curriculum
+from .curriculum_sync_wrapper import (
+    CurriculumWrapper,
+    MultiProcessingCurriculumWrapper,
+    RayCurriculumWrapper,
+    make_multiprocessing_curriculum,
+    make_ray_curriculum,
+)
+from .environment_sync_wrapper import (
+    MultiProcessingSyncWrapper,
+    PettingZooMultiProcessingSyncWrapper,
+    PettingZooRaySyncWrapper,
+    RaySyncWrapper,
+)
+from .multivariate_curriculum_wrapper import MultitaskWrapper
+from .task_interface import (
+    PettingZooTaskEnv,
+    PettingZooTaskWrapper,
+    ReinitTaskWrapper,
+    SubclassTaskWrapper,
+    TaskEnv,
+    TaskWrapper,
+)
 
 # Curriculum Code
-from .utils import decorate_all_functions, UsageError, enumerate_axes
-from .curriculum_base import Curriculum
-from .curriculum_sync_wrapper import (CurriculumWrapper,
-                                      MultiProcessingCurriculumWrapper,
-                                      RayCurriculumWrapper,
-                                      make_multiprocessing_curriculum,
-                                      make_ray_curriculum)
-
-from .environment_sync_wrapper import MultiProcessingSyncWrapper, RaySyncWrapper, PettingZooMultiProcessingSyncWrapper, PettingZooRaySyncWrapper
-from .multivariate_curriculum_wrapper import MultitaskWrapper
+from .utils import UsageError, decorate_all_functions, enumerate_axes

--- a/syllabus/core/curriculum_sync_wrapper.py
+++ b/syllabus/core/curriculum_sync_wrapper.py
@@ -1,17 +1,19 @@
 import threading
+import time
 from functools import wraps
 from typing import List, Tuple
 
 import ray
-import time
 from torch.multiprocessing import SimpleQueue
 
-from syllabus.core import Curriculum, decorate_all_functions
+from syllabus.core import Curriculum
+
+from .utils import decorate_all_functions  # fixed circular import
 
 
 class CurriculumWrapper:
-    """Wrapper class for adding multiprocessing synchronization to a curriculum.
-    """
+    """Wrapper class for adding multiprocessing synchronization to a curriculum."""
+
     def __init__(self, curriculum: Curriculum) -> None:
         self.curriculum = curriculum
         self.task_space = curriculum.task_space
@@ -26,7 +28,7 @@ class CurriculumWrapper:
 
     @property
     def tasks(self):
-        return self.task_space.tasks   
+        return self.task_space.tasks
 
     def get_tasks(self, task_space=None):
         return self.task_space.get_tasks(gym_space=task_space)
@@ -57,13 +59,15 @@ class CurriculumWrapper:
 
 
 class MultiProcessingCurriculumWrapper(CurriculumWrapper):
-    """Wrapper which sends tasks and receives updates from environments wrapped in a corresponding MultiprocessingSyncWrapper.
-    """
-    def __init__(self,
-                 curriculum: Curriculum,
-                 task_queue: SimpleQueue,
-                 update_queue: SimpleQueue,
-                 sequential_start: bool = True):
+    """Wrapper which sends tasks and receives updates from environments wrapped in a corresponding MultiprocessingSyncWrapper."""
+
+    def __init__(
+        self,
+        curriculum: Curriculum,
+        task_queue: SimpleQueue,
+        update_queue: SimpleQueue,
+        sequential_start: bool = True,
+    ):
         super().__init__(curriculum)
         self.task_queue = task_queue
         self.update_queue = update_queue
@@ -78,7 +82,9 @@ class MultiProcessingCurriculumWrapper(CurriculumWrapper):
         """
         Start the thread that reads the complete_queue and reads the task_queue.
         """
-        self.update_thread = threading.Thread(name='update', target=self._update_queues, daemon=True)
+        self.update_thread = threading.Thread(
+            name="update", target=self._update_queues, daemon=True
+        )
         self.should_update = True
         self.update_thread.start()
 
@@ -106,18 +112,27 @@ class MultiProcessingCurriculumWrapper(CurriculumWrapper):
                         requested_tasks += 1
                     # Decode task and task progress
                     if update["update_type"] == "task_progress":
-                        update["metrics"] = (self.task_space.decode(update["metrics"][0]), update["metrics"][1])
+                        update["metrics"] = (
+                            self.task_space.decode(update["metrics"][0]),
+                            update["metrics"][1],
+                        )
                 self.batch_update(batch_updates)
 
             # Sample new tasks
             if requested_tasks > 0:
                 # TODO: Move this to curriculum, not sync wrapper
                 # Sequentially sample task_space before using curriculum method
-                if (self.sequential_start and
-                        self.task_space.num_tasks is not None and
-                        self.num_assigned_tasks + requested_tasks < self.task_space.num_tasks):
+                if (
+                    self.sequential_start
+                    and self.task_space.num_tasks is not None
+                    and self.num_assigned_tasks + requested_tasks
+                    < self.task_space.num_tasks
+                ):
                     # Sample unseen tasks sequentially before using curriculum method
-                    new_tasks = self.task_space.list_tasks()[self.num_assigned_tasks:self.num_assigned_tasks + requested_tasks]
+                    new_tasks = self.task_space.list_tasks()[
+                        self.num_assigned_tasks : self.num_assigned_tasks
+                        + requested_tasks
+                    ]
                 else:
                     new_tasks = self.curriculum.sample(k=requested_tasks)
                 for i, task in enumerate(new_tasks):
@@ -149,6 +164,7 @@ def remote_call(func):
 
     Note that this causes functions to block, and should be only used for operations that do not require parallelization.
     """
+
     @wraps(func)
     def wrapper(self, *args, **kw):
         f_name = func.__name__
@@ -159,6 +175,7 @@ def remote_call(func):
         if child_func == parent_func:
             curriculum_func = getattr(self.curriculum, f_name)
             return ray.get(curriculum_func.remote(*args, **kw))
+
     return wrapper
 
 
@@ -168,7 +185,9 @@ def make_multiprocessing_curriculum(curriculum, **kwargs):
     """
     task_queue = SimpleQueue()
     update_queue = SimpleQueue()
-    mp_curriculum = MultiProcessingCurriculumWrapper(curriculum, task_queue, update_queue, **kwargs)
+    mp_curriculum = MultiProcessingCurriculumWrapper(
+        curriculum, task_queue, update_queue, **kwargs
+    )
     mp_curriculum.start()
     return mp_curriculum, task_queue, update_queue
 
@@ -190,6 +209,7 @@ class RayCurriculumWrapper(CurriculumWrapper):
     for convenience.
     # TODO: Implement the Curriculum methods explicitly
     """
+
     def __init__(self, curriculum, actor_name="curriculum") -> None:
         super().__init__(curriculum)
         self.curriculum = RayWrapper.options(name=actor_name).remote(curriculum)
@@ -202,7 +222,9 @@ class RayCurriculumWrapper(CurriculumWrapper):
     def sample(self, k: int = 1):
         return ray.get(self.curriculum.sample.remote(k=k))
 
-    def update_on_step_batch(self, step_results: List[Tuple[int, int, int, int]]) -> None:
+    def update_on_step_batch(
+        self, step_results: List[Tuple[int, int, int, int]]
+    ) -> None:
         ray.get(self.curriculum._on_step_batch.remote(step_results))
 
     def add_task(self, task):

--- a/syllabus/examples/experimental/multi_car_racing.py
+++ b/syllabus/examples/experimental/multi_car_racing.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 from gymnasium import spaces
+from supersuit import color_reduction_v0, frame_stack_v1, resize_v1
 from torch.distributions.normal import Normal
 from tqdm.auto import tqdm
 
@@ -27,36 +28,33 @@ def layer_init(layer, std=np.sqrt(2), bias_const=0.0):
 
 
 class Agent(nn.Module):
-    def __init__(self, envs):
+    def __init__(self):
         super().__init__()
+        self.observation_shape = (3, 96, 96)
+        self.action_shape = (3,)
+
         self.critic = nn.Sequential(
-            layer_init(
-                nn.Linear(np.array(envs.single_observation_space.shape).prod(), 64)
-            ),
+            layer_init(nn.Linear(np.array(self.observation_shape).prod(), 64)),
             nn.Tanh(),
             layer_init(nn.Linear(64, 64)),
             nn.Tanh(),
             layer_init(nn.Linear(64, 1), std=1.0),
         )
         self.actor_mean = nn.Sequential(
-            layer_init(
-                nn.Linear(np.array(envs.single_observation_space.shape).prod(), 64)
-            ),
+            layer_init(nn.Linear(np.array(self.observation_shape).prod(), 64)),
             nn.Tanh(),
             layer_init(nn.Linear(64, 64)),
             nn.Tanh(),
-            layer_init(
-                nn.Linear(64, np.prod(envs.single_action_space.shape)), std=0.01
-            ),
+            layer_init(nn.Linear(64, np.prod(self.action_shape)), std=0.01),
         )
-        self.actor_logstd = nn.Parameter(
-            torch.zeros(1, np.prod(envs.single_action_space.shape))
-        )
+        self.actor_logstd = nn.Parameter(torch.zeros(1, np.prod(self.action_shape)))
 
     def get_value(self, x):
         return self.critic(x)
 
     def get_action_and_value(self, x, action=None):
+        x = x.float().reshape(x.size(0), -1)
+
         action_mean = self.actor_mean(x)
         action_logstd = self.actor_logstd.expand_as(action_mean)
         action_std = torch.exp(action_logstd)
@@ -121,6 +119,9 @@ class MultiCarRacingParallelWrapper(TaskWrapper):
                 dtype=np.float32,
             )
         )
+        self.possible_agents = np.arange(
+            self.n_agents
+        )  # TODO: is this the intended use?
 
     def _actions_pz_to_np(self, action: dict[AgentID, ActionType]) -> np.ndarray:
         """
@@ -191,11 +192,16 @@ if __name__ == "__main__":
     clip_coef = 0.1
     gamma = 0.99
     batch_size = 32
-    stack_size = 4
+    stack_size = 3
     frame_size = (96, 96)
+    action_size = 3
     max_cycles = 125
     total_episodes = 100
 
+    # PLR Params
+    num_steps = 128
+
+    """ ENV SETUP """
     n_agents = 2
     env = gym.make(
         "MultiCarRacing-v0",
@@ -212,25 +218,194 @@ if __name__ == "__main__":
     curriculum = DomainRandomization(env.task_space)
     curriculum, task_queue, update_queue = make_multiprocessing_curriculum(curriculum)
 
-    # TODO: clarify how to setup continuous PPO
-    # """ LEARNER SETUP """
-    # agent = Agent(envs=envs).to(device)
-    # optimizer = optim.Adam(agent.parameters(), lr=0.001, eps=1e-5)
+    """ LEARNER SETUP """
+    agent = Agent().to(device)
+    optimizer = optim.Adam(agent.parameters(), lr=0.001, eps=1e-5)
+
+    """ ALGO LOGIC: EPISODE STORAGE"""
+    end_step = 0
+    total_episodic_return = 0
+    rb_obs = torch.zeros((max_cycles, n_agents, stack_size, *frame_size)).to(device)
+    rb_actions = torch.zeros((max_cycles, n_agents, action_size)).to(device)
+    rb_logprobs = torch.zeros((max_cycles, n_agents)).to(device)
+    rb_rewards = torch.zeros((max_cycles, n_agents)).to(device)
+    rb_dones = torch.zeros((max_cycles, n_agents)).to(device)
+    rb_values = torch.zeros((max_cycles, n_agents)).to(device)
 
     done = {i: False for i in range(n_agents)}
     total_reward = {i: 0 for i in range(n_agents)}
     np.random.seed(0)
 
-    # while not all(done.values()):
-    for episodes in tqdm(range(5)):  # testing with 5 truncated episodes
-        obs = env.reset()
-        for steps in range(100):
-            action = np.random.normal(0, 1, (2, 3))
-            pz_action = {i: action[i] for i in range(n_agents)}
-            obs, reward, done, trunc, info = env.step(pz_action)
-            for agent in range(n_agents):
-                total_reward[agent] += reward[agent]
-            env.render()
+    """ TRAINING LOGIC """
+    # train for n number of episodes
+    global_cycles = 0
+    for episode in tqdm(range(total_episodes)):
+        # collect an episode
+        with torch.no_grad():
+            # collect observations and convert to batch of torch tensors
+            next_obs = env.reset()
+            # reset the episodic return
+            total_episodic_return = 0
 
-    print("individual scores:", total_reward)
-    print(reward, done, trunc, info)
+            # each episode has num_steps
+            for step in range(0, max_cycles):
+                global_cycles += 1
+                # rollover the observation
+                obs = batchify_obs(next_obs, device)
+                # get action from the agent
+                actions, logprobs, entropy, values = agent.get_action_and_value(obs)
+
+                # execute the environment and log data
+                next_obs, rewards, trunc, dones, infos = env.step(
+                    unbatchify(actions, env)
+                )
+
+                # add to episode storage
+                rb_obs[step] = obs
+                rb_rewards[step] = batchify(rewards, device)
+                rb_dones[step] = batchify(dones, device)
+                rb_actions[step] = actions
+                rb_logprobs[step] = logprobs
+                rb_values[step] = values.flatten()
+
+                # compute episodic return
+                total_episodic_return += rb_rewards[step].cpu().numpy()
+
+                # Update curriculum
+                # TODO: adapt to DR
+                if global_cycles % num_steps == 0:
+                    update = {
+                        "update_type": "on_demand",
+                        "metrics": {
+                            "action_log_dist": logprobs,
+                            "value": values,
+                            "next_value": (
+                                agent.get_value(next_obs)
+                                if step == num_steps - 1
+                                else None
+                            ),
+                            "rew": rb_rewards[step],
+                            "masks": torch.Tensor(1 - np.array(list(dones.values()))),
+                            "tasks": [env.unwrapped.task],
+                        },
+                    }
+                    curriculum.update_curriculum(update)
+
+                # if we reach the end of the episode
+                if any([dones[a] for a in dones]):
+                    print(f"Breaking early at step {step} due to done signal.")
+                    end_step = step
+                    break
+
+        # bootstrap value if not done
+        with torch.no_grad():
+            rb_advantages = torch.zeros_like(rb_rewards).to(device)
+            for t in reversed(range(end_step)):
+                delta = (
+                    rb_rewards[t]
+                    + gamma * rb_values[t + 1] * rb_dones[t + 1]
+                    - rb_values[t]
+                )
+                rb_advantages[t] = delta + gamma * gamma * rb_advantages[t + 1]
+            rb_returns = rb_advantages + rb_values
+
+        # TODO: at this step, `end_step` is still 0, causing b_obs to be empty
+        # and the `repeat` loop not running as range(0, len(b_obs), batch_size) = 0
+        # maybe set end_step to the current number of steps in the episode even if there
+        # is no positive done flag ?
+
+        # convert our episodes to batch of individual transitions
+        b_obs = torch.flatten(rb_obs[:end_step], start_dim=0, end_dim=1)
+        b_logprobs = torch.flatten(rb_logprobs[:end_step], start_dim=0, end_dim=1)
+        b_actions = torch.flatten(rb_actions[:end_step], start_dim=0, end_dim=1)
+        b_returns = torch.flatten(rb_returns[:end_step], start_dim=0, end_dim=1)
+        b_values = torch.flatten(rb_values[:end_step], start_dim=0, end_dim=1)
+        b_advantages = torch.flatten(rb_advantages[:end_step], start_dim=0, end_dim=1)
+
+        # Optimizing the policy and value network
+        b_index = np.arange(len(b_obs))
+        clip_fracs = []
+        for repeat in range(3):
+            # shuffle the indices we use to access the data
+            np.random.shuffle(b_index)
+            for start in range(0, len(b_obs), batch_size):
+                print(start)
+                # select the indices we want to train on
+                end = start + batch_size
+                batch_index = b_index[start:end]
+
+                _, newlogprob, entropy, value = agent.get_action_and_value(
+                    b_obs[batch_index], b_actions.long()[batch_index]
+                )
+                logratio = newlogprob - b_logprobs[batch_index]
+                ratio = logratio.exp()
+
+                with torch.no_grad():
+                    # calculate approx_kl http://joschu.net/blog/kl-approx.html
+                    old_approx_kl = (-logratio).mean()
+                    approx_kl = ((ratio - 1) - logratio).mean()
+                    clip_fracs += [
+                        ((ratio - 1.0).abs() > clip_coef).float().mean().item()
+                    ]
+
+                # normalize advantaegs
+                advantages = b_advantages[batch_index]
+                advantages = (advantages - advantages.mean()) / (
+                    advantages.std() + 1e-8
+                )
+
+                # Policy loss
+                pg_loss1 = -b_advantages[batch_index] * ratio
+                pg_loss2 = -b_advantages[batch_index] * torch.clamp(
+                    ratio, 1 - clip_coef, 1 + clip_coef
+                )
+                pg_loss = torch.max(pg_loss1, pg_loss2).mean()
+
+                # Value loss
+                value = value.flatten()
+                v_loss_unclipped = (value - b_returns[batch_index]) ** 2
+                v_clipped = b_values[batch_index] + torch.clamp(
+                    value - b_values[batch_index],
+                    -clip_coef,
+                    clip_coef,
+                )
+                v_loss_clipped = (v_clipped - b_returns[batch_index]) ** 2
+                v_loss_max = torch.max(v_loss_unclipped, v_loss_clipped)
+                v_loss = 0.5 * v_loss_max.mean()
+                entropy_loss = entropy.mean()
+                loss = pg_loss - ent_coef * entropy_loss + v_loss * vf_coef
+
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+
+        y_pred, y_true = b_values.cpu().numpy(), b_returns.cpu().numpy()
+        var_y = np.var(y_true)
+        explained_var = np.nan if var_y == 0 else 1 - np.var(y_true - y_pred) / var_y
+
+        print(f"Training episode {episode}")
+        print(f"Episodic Return: {np.mean(total_episodic_return)}")
+        print(f"Episode Length: {end_step}")
+        print("")
+        print(f"Value Loss: {v_loss.item()}")
+        print(f"Policy Loss: {pg_loss.item()}")
+        print(f"Old Approx KL: {old_approx_kl.item()}")
+        print(f"Approx KL: {approx_kl.item()}")
+        print(f"Clip Fraction: {np.mean(clip_fracs)}")
+        print(f"Explained Variance: {explained_var.item()}")
+        print("\n-------------------------------------------\n")
+
+    # ----- Dummy test loop -----
+    # while not all(done.values()):
+    # for episodes in tqdm(range(1)):  # testing with 5 truncated episodes
+    #     obs = env.reset()
+    #     for steps in range(100):
+    #         action = np.random.normal(0, 1, (2, 3))
+    #         pz_action = {i: action[i] for i in range(n_agents)}
+    #         obs, reward, done, trunc, info = env.step(pz_action)
+    #         for agent in range(n_agents):
+    #             total_reward[agent] += reward[agent]
+    #         env.render()
+
+    # print("individual scores:", total_reward)
+    # print(reward, done, trunc, info)

--- a/syllabus/examples/experimental/multi_car_racing.py
+++ b/syllabus/examples/experimental/multi_car_racing.py
@@ -4,10 +4,12 @@ from typing import TypeVar
 import gym
 import gym_multi_car_racing
 import numpy as np
-from gym.spaces import Box
+from gymnasium import spaces
 from tqdm.auto import tqdm
 
-from syllabus.core import TaskWrapper
+from syllabus.core import TaskWrapper, make_multiprocessing_curriculum
+from syllabus.curricula import DomainRandomization
+from syllabus.task_space import TaskSpace
 
 ObsType = TypeVar("ObsType")
 ActionType = TypeVar("ActionType")
@@ -17,6 +19,12 @@ AgentID = TypeVar("AgentID")
 class MultiCarRacingParallelWrapper(TaskWrapper):
     """
     Wrapper ensuring compatibility with the PettingZoo Parallel API.
+
+    Car Racing Environment:
+        * Action shape:  ``n_agents`` * `Box([-1. 0. 0.], 1.0, (3,), float32)`
+        * Observation shape: ``n_agents`` * `Box(0, 255, (96, 96, 3), uint8)`
+        * Done: ``done`` is a single boolean value
+        * Info: ``info`` is unused and represented as an empty dictionary
     """
 
     def __init__(self, n_agents, *args, **kwargs):
@@ -33,8 +41,31 @@ class MultiCarRacingParallelWrapper(TaskWrapper):
         assert action.shape == (self.n_agents, 3)
         return action
 
-    def reset(self):
-        pass
+    def _np_array_to_pz_dict(self, array: np.ndarray) -> dict[int : np.ndarray]:
+        """
+        Returns a dictionary containing individual observations for each agent.
+        """
+        out = {}
+        for idx, i in enumerate(array):
+            out[idx] = i
+        return out
+
+    def _singleton_to_pz_dict(self, value: bool) -> dict[int:bool]:
+        """
+        Broadcasts the `done` and `trunc` flags to dictionaries keyed by agent id.
+        """
+        return {idx: value for idx in range(self.n_agents)}
+
+    def reset(self) -> tuple[dict[AgentID, ObsType], dict[AgentID, dict]]:
+        """
+        Resets the environment and returns a dictionary of observations
+        keyed by agent ID.
+        """
+        # TODO: what is the second output (dict[AgentID, dict]])?
+        obs = self.env.reset()
+        pz_obs = self._np_array_to_pz_dict(obs)
+
+        return pz_obs
 
     def step(self, action: dict[AgentID, ActionType]) -> tuple[
         dict[AgentID, ObsType],
@@ -47,33 +78,16 @@ class MultiCarRacingParallelWrapper(TaskWrapper):
         Takes inputs in the PettingZoo (PZ) Parallel API format, performs a step and
         returns outputs in PZ format.
         """
-
-        def _np_array_to_pz_dict(array: np.ndarray):
-            """
-            Converts an n-dimensional numpy array to a dictionary
-            with n keys and values.
-            """
-            out = {}
-            for idx, i in enumerate(array):
-                out[idx] = i
-            return out
-
-        def _singleton_to_pz_dict(value: bool):
-            """
-            Converts a boolean flag to a dictionary with ``n_agents`` keys and values.
-            """
-            return {idx: value for idx in range(self.n_agents)}
-
         # convert action to numpy format to perform the env step
         np_action = self._actions_pz_to_np(action)
         obs, rew, term, info = self.env.step(np_action)
         trunc = 0  # there is no `truncated` flag in this environment
         self.task_completion = self._task_completion(obs, rew, term, trunc, info)
-        info["task_completion"] = self.task_completion
         # convert outputs back to PZ format
-        obs, rew = tuple(map(_np_array_to_pz_dict, [obs, rew]))
-        # TODO: are boolean flags replicated `n_agent` times in PZ format ?
-        term, trunc = tuple(map(_singleton_to_pz_dict, [term, trunc]))
+        obs, rew = tuple(map(self._np_array_to_pz_dict, [obs, rew]))
+        term, trunc, info = tuple(
+            map(self._singleton_to_pz_dict, [term, trunc, self.task_completion])
+        )
 
         return self.observation(obs), rew, term, trunc, info
 
@@ -90,30 +104,26 @@ if __name__ == "__main__":
         use_ego_color=False,
     )
 
-    obs = env.reset()
     env = MultiCarRacingParallelWrapper(env=env, n_agents=n_agents)
+    # curriculum = DomainRandomization(env)
+    # curriculum, task_queue, update_queue = make_multiprocessing_curriculum(
+    #     curriculum,
+    # )
+
     done = {i: False for i in range(n_agents)}
     total_reward = {i: 0 for i in range(n_agents)}
     np.random.seed(0)
 
     # while not all(done.values()):
-    for steps in tqdm(range(100)):
-        # The actions have to be of the format (num_agents,3)
-        # The action format for each car is as in the CarRacing-v0 environment
-        # i.e. (`Box([-1. 0. 0.], 1.0, (3,), float32)`)
-        action = np.random.normal(0, 1, (2, 3))
-
-        assert action.shape == (n_agents, 3)
-        pz_action = {i: action[i] for i in range(n_agents)}
-        # Similarly, the structure of this is the same as in CarRacing-v0 with an
-        # additional dimension for the different agents, i.e.
-        # obs is of shape (num_agents, 96, 96, 3)
-        # reward is of shape (num_agents,)
-        # done is a bool and info is not used (an empty dict).
-        obs, reward, done, trunc, info = env.step(pz_action)
-        for agent in range(n_agents):
-            total_reward[agent] += reward[agent]
-        env.render()
+    for episodes in tqdm(range(5)):  # testing with 5 truncated episodes
+        obs = env.reset()
+        for steps in range(100):
+            action = np.random.normal(0, 1, (2, 3))
+            pz_action = {i: action[i] for i in range(n_agents)}
+            obs, reward, done, trunc, info = env.step(pz_action)
+            for agent in range(n_agents):
+                total_reward[agent] += reward[agent]
+            env.render()
 
     print("individual scores:", total_reward)
     print(reward, done, trunc, info)

--- a/syllabus/examples/experimental/multi_car_racing.py
+++ b/syllabus/examples/experimental/multi_car_racing.py
@@ -1,0 +1,119 @@
+# flake8: noqa: F401
+from typing import TypeVar
+
+import gym
+import gym_multi_car_racing
+import numpy as np
+from gym.spaces import Box
+from tqdm.auto import tqdm
+
+from syllabus.core import TaskWrapper
+
+ObsType = TypeVar("ObsType")
+ActionType = TypeVar("ActionType")
+AgentID = TypeVar("AgentID")
+
+
+class MultiCarRacingParallelWrapper(TaskWrapper):
+    """
+    Wrapper ensuring compatibility with the PettingZoo Parallel API.
+    """
+
+    def __init__(self, n_agents, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.n_agents = n_agents
+
+    def _actions_pz_to_np(self, action: dict[AgentID, ActionType]) -> np.ndarray:
+        """
+        Converts actions defined in PZ format to a numpy array.
+        """
+        assert action.__len__() == self.n_agents
+
+        action = np.array(list(action.values()))
+        assert action.shape == (self.n_agents, 3)
+        return action
+
+    def reset(self):
+        pass
+
+    def step(self, action: dict[AgentID, ActionType]) -> tuple[
+        dict[AgentID, ObsType],
+        dict[AgentID, float],
+        dict[AgentID, bool],
+        dict[AgentID, bool],
+        dict[AgentID, dict],
+    ]:
+        """
+        Takes inputs in the PettingZoo (PZ) Parallel API format, performs a step and
+        returns outputs in PZ format.
+        """
+
+        def _np_array_to_pz_dict(array: np.ndarray):
+            """
+            Converts an n-dimensional numpy array to a dictionary
+            with n keys and values.
+            """
+            out = {}
+            for idx, i in enumerate(array):
+                out[idx] = i
+            return out
+
+        def _singleton_to_pz_dict(value: bool):
+            """
+            Converts a boolean flag to a dictionary with ``n_agents`` keys and values.
+            """
+            return {idx: value for idx in range(self.n_agents)}
+
+        # convert action to numpy format to perform the env step
+        np_action = self._actions_pz_to_np(action)
+        obs, rew, term, info = self.env.step(np_action)
+        trunc = 0  # there is no `truncated` flag in this environment
+        self.task_completion = self._task_completion(obs, rew, term, trunc, info)
+        info["task_completion"] = self.task_completion
+        # convert outputs back to PZ format
+        obs, rew = tuple(map(_np_array_to_pz_dict, [obs, rew]))
+        # TODO: are boolean flags replicated `n_agent` times in PZ format ?
+        term, trunc = tuple(map(_singleton_to_pz_dict, [term, trunc]))
+
+        return self.observation(obs), rew, term, trunc, info
+
+
+if __name__ == "__main__":
+    n_agents = 2
+    env = gym.make(
+        "MultiCarRacing-v0",
+        num_agents=n_agents,
+        direction="CCW",
+        use_random_direction=True,
+        backwards_flag=True,
+        h_ratio=0.25,
+        use_ego_color=False,
+    )
+
+    obs = env.reset()
+    env = MultiCarRacingParallelWrapper(env=env, n_agents=n_agents)
+    done = {i: False for i in range(n_agents)}
+    total_reward = {i: 0 for i in range(n_agents)}
+    np.random.seed(0)
+
+    # while not all(done.values()):
+    for steps in tqdm(range(100)):
+        # The actions have to be of the format (num_agents,3)
+        # The action format for each car is as in the CarRacing-v0 environment
+        # i.e. (`Box([-1. 0. 0.], 1.0, (3,), float32)`)
+        action = np.random.normal(0, 1, (2, 3))
+
+        assert action.shape == (n_agents, 3)
+        pz_action = {i: action[i] for i in range(n_agents)}
+        # Similarly, the structure of this is the same as in CarRacing-v0 with an
+        # additional dimension for the different agents, i.e.
+        # obs is of shape (num_agents, 96, 96, 3)
+        # reward is of shape (num_agents,)
+        # done is a bool and info is not used (an empty dict).
+        obs, reward, done, trunc, info = env.step(pz_action)
+        for agent in range(n_agents):
+            total_reward[agent] += reward[agent]
+        env.render()
+
+    print("individual scores:", total_reward)
+    print(reward, done, trunc, info)


### PR DESCRIPTION
Here's the current state of my work on `multi_car_racing` and Domain Randomization:

## Installation:

* Running the script still requires Docker for now, I also copied the `multi_car_racing` repository for convenience (for some reason installing and importing as usual didn't work), this will be cleaned up later when we are ready to move on to later stages of the project

* I upgraded the pettingZoo version to 1.23 and supersuit to 3.7.2 as pettingZoo < 1.23 had a typo preventing an import (`BaseParallelWraper` renamed to `BaseParallelWrapper`)

* There was a circular import in `curriculum_sync_wrapper.py`
```python
from syllabus.core import Curriculum, decorate_all_functions # circular import

from syllabus.core import Curriculum
from .utils import decorate_all_functions  # fixed the problem

```

## Script:

* The task wrapper for `multi_car_racing` seems to work as expected

* The curriculum setup is executed without any error: 

```python
env = MultiCarRacingParallelWrapper(env=env, n_agents=n_agents)
curriculum = DomainRandomization(env.task_space)
curriculum, task_queue, update_queue = make_multiprocessing_curriculum(curriculum)
```

* However, I'm still unsure of how to update the DR curriculum compared to PLR: 
  
```python
# TODO: adapt to DR
if global_cycles % num_steps == 0:
    update = {
        "update_type": "on_demand",
        "metrics": {
            "action_log_dist": logprobs,
            "value": values,
            "next_value": (
                agent.get_value(next_obs)
                if step == num_steps - 1
                else None
            ),
            "rew": rb_rewards[step],
            "masks": torch.Tensor(1 - np.array(list(dones.values()))),
            "tasks": [env.unwrapped.task],
        },
    }
    curriculum.update_curriculum(update)
```

* Finally, I attempted to implement continuous PPO by using this [cleanrl ``ppo_continuous_action`` architecture](https://github.com/vwxyzjn/cleanrl/blob/master/cleanrl/ppo_continuous_action.py) along with the [`cleanrl_pettingzoo_pistonball_plr`](https://github.com/RyanNavillus/Syllabus/blob/nmmo/syllabus/examples/experimental/cleanrl_pettingzoo_pistonball_plr.py) training script (with minor adjustments).

I'm still solving bugs and progressing through the script. For now it seems that the `end_step` variable prevents the loop containing the backward pass to run (`end_step` is equal to 0, therefore `b_obs = torch.flatten(rb_obs[:end_step], start_dim=0, end_dim=1)` is empty and `for start in range(0, len(b_obs), batch_size)` doesn't iterate properly).

Could this be due to the fact that the `pistonball_plr` script is unfinished ? (In hindsight I should've chosen a training loop that wasn't in the `experimental` folder)
